### PR TITLE
fix: github pages publish action

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -6,9 +6,8 @@
 
 name: Publish Github Pages
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    - cron: "0 */1 * * *" # every hour
   workflow_dispatch:
 jobs:
   action:


### PR DESCRIPTION
Changelog
----
- The branch-based trigger is not working. Switch to cron-based trigger for gh page action
- This is set to run every hour.

Fixes https://github.com/chatwoot/chatwoot-contributors/issues/3